### PR TITLE
Entire updates and improvements by review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *~
 .vscode/
 .idea/
+CLAUDE.md
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,41 @@ representing the healthy rhythm between focused work and proper rest.
 It uses macOS built-in accessibility features and Hammerspoon.
 Simple, lightweight, and reliable.
 
+## Quick Start (English)
+
+### Requirements
+- macOS
+- [Hammerspoon](https://www.hammerspoon.org/) (`brew install --cask hammerspoon`)
+
+### Install
+1. Ensure **System Settings > Accessibility > Display > Color Filters** is set to **Grayscale**
+2. Ensure **System Settings > Accessibility > Shortcut** has only **Color Filters** checked
+3. Clone and run setup:
+   ```bash
+   git clone https://github.com/tadokoro88/merihari.git
+   cd merihari
+   ./setup.sh
+   ```
+4. Launch Hammerspoon, grant Accessibility permissions, and allow notifications
+5. Enable "Launch Hammerspoon at login" in Hammerspoon Preferences
+6. Click the Hammerspoon menu bar icon > **Reload Config**
+
+### How it works
+- Checks every 60 seconds and toggles grayscale on/off based on your configured time window
+- During the active window: grayscale is enforced and a reminder notification is sent every minute
+- Manual overrides are automatically corrected within 60 seconds
+- Skips toggling during lock/sleep; resyncs on wake/unlock
+- On display connect/disconnect, forces a display refresh to keep filters consistent
+
+### Uninstall
+```bash
+cd merihari
+./delete.sh
+```
+Then click Hammerspoon menu bar icon > **Reload Config**.
+
+---
+
 # Merihari (macOS)
 指定した時間帯は画面をグレースケールにします（例: 21:00-翌6:00）。
 macOS標準のアクセシビリティ設定（grayscale）を Hammerspoon で自動切替します。

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,19 @@ On session activation-related events (wake/unlock/become-active):
 - Keep runtime timer/watcher references alive for the lifetime of the config.
 - Avoid complex gating that can stall all future checks.
 
+## Screen Topology Resync
+When an external display is connected/disconnected (screen topology change), macOS may not apply the color filter consistently across all displays.
+
+On topology change (debounced by 2 seconds):
+1. Skip if session is locked/asleep (`screen_resync_allowed` flag).
+2. Skip if within cooldown period (20 seconds since last resync).
+3. Skip if no recent toggle or activation event occurred (within 300 seconds).
+4. If the current filter state already matches the desired state, double-toggle (off-on or on-off-on) to force macOS to refresh the filter across all displays.
+5. If the state is wrong, single-toggle to correct it.
+6. After resync settles, run a normal `apply_state()` for verification.
+
+The `screen_resync_allowed` flag is set to `false` on lock/sleep events and `true` on unlock/activation events, preventing resync attempts during inactive sessions.
+
 ## Non-Goals
 - Perfect lock/sleep detection in all macOS edge cases.
 - Zero transient toggle failures during wake/login timing windows.

--- a/init.lua
+++ b/init.lua
@@ -169,25 +169,27 @@ local function apply_state(source)
     if should_be_on and not is_on then
         debug_log("attempt turn ON")
         toggle_grayscale()
-        hs.timer.usleep(300000)
-        if is_grayscale_on() then
-            reset_failure_count("on")
-            runtime.last_toggle_ts = os.time()
-            print("Merihari: turned ON")
-        else
-            log_every_five_failures("on")
-        end
+        hs.timer.doAfter(0.3, function()
+            if is_grayscale_on() then
+                reset_failure_count("on")
+                runtime.last_toggle_ts = os.time()
+                print("Merihari: turned ON")
+            else
+                log_every_five_failures("on")
+            end
+        end)
     elseif not should_be_on and is_on then
         debug_log("attempt turn OFF")
         toggle_grayscale()
-        hs.timer.usleep(300000)
-        if not is_grayscale_on() then
-            reset_failure_count("off")
-            runtime.last_toggle_ts = os.time()
-            print("Merihari: turned OFF")
-        else
-            log_every_five_failures("off")
-        end
+        hs.timer.doAfter(0.3, function()
+            if not is_grayscale_on() then
+                reset_failure_count("off")
+                runtime.last_toggle_ts = os.time()
+                print("Merihari: turned OFF")
+            else
+                log_every_five_failures("off")
+            end
+        end)
     end
 
     if should_be_on then
@@ -227,42 +229,29 @@ local function resync_after_screen_change()
 
     runtime.last_screen_resync_ts = now_ts
 
-    local start, end_time = read_config()
     local skip, reason, active = should_skip_for_inactive_session()
     if skip then
         debug_log("skip resync source=screenChanged reason=" .. tostring(reason) .. " active=" .. tostring(active))
         return
     end
 
+    local start, end_time = read_config()
     local should_be_on = should_be_grayscale(start, end_time)
     local is_on = is_grayscale_on()
     debug_log("screenChanged resync should_be_on=" .. tostring(should_be_on) .. " is_on=" .. tostring(is_on))
 
-    -- Force a global re-apply across displays by toggling to opposite then back to desired.
-    if should_be_on then
-        if is_on then
-            debug_log("screenChanged resync: ON->OFF->ON")
-            toggle_grayscale()
-            hs.timer.usleep(400000)
-            toggle_grayscale()
-        else
-            debug_log("screenChanged resync: OFF->ON")
-            toggle_grayscale()
-        end
+    -- Force display refresh: double-toggle if already correct, single toggle if not.
+    if should_be_on == is_on then
+        debug_log("screenChanged resync: double-toggle to refresh displays")
+        toggle_grayscale()
+        hs.timer.doAfter(0.4, function() toggle_grayscale() end)
     else
-        if not is_on then
-            debug_log("screenChanged resync: OFF->ON->OFF")
-            toggle_grayscale()
-            hs.timer.usleep(400000)
-            toggle_grayscale()
-        else
-            debug_log("screenChanged resync: ON->OFF")
-            toggle_grayscale()
-        end
+        debug_log("screenChanged resync: single toggle to correct state")
+        toggle_grayscale()
     end
 
-    -- Run normal state correction after resync.
-    hs.timer.doAfter(1, function()
+    -- Run normal state correction after resync settles.
+    hs.timer.doAfter(1.5, function()
         apply_state("event:screenChanged")
     end)
 end

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,13 @@ if [[ "$START" -ge 2400 ]] || [[ "$END" -ge 2400 ]]; then
   exit 1
 fi
 
+START_M=${START:2:2}
+END_M=${END:2:2}
+if [[ "$START_M" -ge 60 ]] || [[ "$END_M" -ge 60 ]]; then
+  echo "ERROR: Minutes must be between 00 and 59"
+  exit 1
+fi
+
 # Save config
 cat > "$CONFIG_FILE" <<EOF
 START=$START


### PR DESCRIPTION
Fixes: #31 

### init.lua
  - Replace blocking usleep with async hs.timer.doAfter for toggle verification and display resync, avoiding blocking Hammerspoon's
   main thread
  - Simplify resync_after_screen_change by collapsing 4-way if/else into 2-way should_be_on == is_on check

### setup.sh
  - Add minute validation (00–59) — previously 2160 would be accepted as valid

### SPEC.md
  - Document Screen Topology Resync behavior (double-toggle, cooldown, guard conditions)

### README.md
  - Add English Quick Start section (Requirements, Install, How it works, Uninstall)